### PR TITLE
overwrite extracted shared lib rather than delete in shutdown hook

### DIFF
--- a/src/main/java/uk/co/electronstudio/Util.java
+++ b/src/main/java/uk/co/electronstudio/Util.java
@@ -4,12 +4,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 public class Util {
 
     public static final String OS_ARCH = System.getProperty("os.arch");
     public static final String OS_NAME = System.getProperty("os.name");
+    public static final String TMP_DIR = System.getProperty("java.io.tmpdir");
     public static final boolean IS_OS_LINUX = OS_NAME.startsWith("Linux") || OS_NAME.startsWith("LINUX");
     public static final boolean IS_OS_LINUX_AMD64 = IS_OS_LINUX && OS_ARCH.startsWith("amd64");
     public static final boolean IS_OS_MAC = OS_NAME.startsWith("Mac");
@@ -28,9 +30,12 @@ public class Util {
     }
 
     public static String extractFileFromResources(String name, String extension) {
-
         try {
-            Path extractedLoc = Files.createTempFile(null, extension).toAbsolutePath();
+            // ensure that the library's temp directory exists in the system temp dir
+            Path libraryTempDir = Paths.get(TMP_DIR, "jaylib-ffm");
+            Files.createDirectories(libraryTempDir);
+
+            // get specified file resource from library jar
             String path = "/" + name + extension;
             InputStream source = null;
             try {
@@ -43,18 +48,11 @@ public class Util {
                 throw new RuntimeException("Couldn't extract "+name+extension+" from resources");
             }
 
+            // copy file into libraryTempDir, overwriting if it already exists
+            Path extractedLoc = libraryTempDir.resolve(name+extension);
             Files.copy(source, extractedLoc, StandardCopyOption.REPLACE_EXISTING);
 
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                public void run() {
-                    try {
-                        Files.delete(extractedLoc);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            });
-
+            // absolute path to extracted file
             return extractedLoc.toString();
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Closes #10

Reworks how Util extracts jaylib-ffm resources from the library jar into the temp dir to workaround an AccessDeniedException when deleting extracted files on shutdown.

Deletion of the extracted files on shutdown fails due to raylib_h_1.LIBRARY_ARENA being automatically managed. This results in the raylib shared lib still being loaded in the jvm at the time the shutdown hook runs, causing the AccessDeniedException.

While we could manually manage the lifetime of the library arena, that doesn't handle cases where the jvm or the native lib crashes or otherwise shuts down unexpectedly such that the shutdown hook doesn't run, resulting in dangling temp files that never get cleaned up.

Instead of extracting resources as a randomly named file on each run, always extract the files using their actual file names into a subdirectory of the system temp directory named: 'jaylib-ffm'. This allows the extracted files to be reliably overwritten on launch rather than trying to delete the extracted files on shutdown.